### PR TITLE
chore(starters): add gatsby-contentful-blog-portfolio

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5262,3 +5262,21 @@
     - Integrated navigation
     - Verbose (i.e., not D.R.Y.) GraphQL queries to get data from
     - Includes plugins for offline support out of the box
+- url: https://gatsby-contentful-portfolio-blog.netlify.com/
+  repo: https://github.com/escapemanuele/gatsby-contentful-blog-portfolio
+  description: Simple gatsby starter for integration with Contentful. The result is a clean and nice website for businesses or freelancers with a blog and a portfolio. 
+  tags:
+    - Blog
+	  - Business
+	  - Entrepreneurship
+    - CMS:Headless
+    - CMS:Contentful
+    - Netlify
+	  - Portfolio
+	  - SEO
+	  - Styling:Other
+  features:
+    - Styled components
+    - Responsive webpage
+    - Portfolio
+	  - Blog


### PR DESCRIPTION
A new starter for Gatsby+Contentful: a portfolio website with a blog

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
